### PR TITLE
fix: union values can not be passed into $in operator

### DIFF
--- a/src/buildFilterBy.test.ts
+++ b/src/buildFilterBy.test.ts
@@ -37,6 +37,7 @@ describe('buildFilterBy', () => {
     expect(buildFilterBy<{ years: number[] }>({ years: { $in: [2022, 2023] } })).toBe('years:[2022,2023]');
     expect(buildFilterBy<{ colors: string[] }>({ colors: { $in: ['Blue', 'Red'] } })).toBe('colors:[`Blue`,`Red`]');
     expect(buildFilterBy<{ checks: boolean[] }>({ checks: { $in: [false] } })).toBe('checks:[false]');
+    expect(buildFilterBy<{ state: 'on' | 'off' }>({ state: { $in: ['on', 'off'] } })).toBe('state:[`on`,`off`]');
   });
 
   it('$and', () => {

--- a/src/buildFilterBy.ts
+++ b/src/buildFilterBy.ts
@@ -13,7 +13,7 @@ export type FilterByBoolean<T extends boolean> = {
   /**
    * Selects the documents where the value of a field equals any value in the specified array
    */
-  $in?: T[];
+  $in?: boolean[];
 };
 
 export type FilterByNumber<T extends number> = {
@@ -40,7 +40,7 @@ export type FilterByNumber<T extends number> = {
   /**
    * Selects the documents where the value of a field equals any value in the specified array
    */
-  $in?: T[];
+  $in?: number[];
 };
 
 export type FilterByString<T extends string = string> = {
@@ -55,7 +55,7 @@ export type FilterByString<T extends string = string> = {
   /**
    * Selects the documents where the value of a field equals any value in the specified array
    */
-  $in?: T[];
+  $in?: string[];
 };
 
 export type FilterByGeopoint = {


### PR DESCRIPTION
Union values are not accepted by `$in` operator because of how union types are inferred. 

For now, I am disabling inferring for `$in` operator.

![image](https://github.com/igrek8/typesense-utils/assets/7078731/f2fc2c95-1366-4af9-b99e-cef8e8eac468)
