### PR TITLE
fix: match by exact value instead of fuzzy

### DIFF
--- a/src/buildFacetQuery.test.ts
+++ b/src/buildFacetQuery.test.ts
@@ -20,6 +20,6 @@ describe('buildFacetQuery', () => {
           },
         },
       })
-    ).toBe('movies.title:`Jumanji`');
+    ).toBe('movies.title:=`Jumanji`');
   });
 });

--- a/src/buildFilterBy.test.ts
+++ b/src/buildFilterBy.test.ts
@@ -11,13 +11,13 @@ describe('buildFilterBy', () => {
   });
 
   it('$eq', () => {
-    expect(buildFilterBy<{ status: 'published' }>({ status: { $eq: 'published' } })).toBe('status:`published`');
-    expect(buildFilterBy<{ price: number }>({ price: { $eq: 100 } })).toBe('price:100');
-    expect(buildFilterBy<{ deleted: boolean }>({ deleted: { $eq: false } })).toBe('deleted:false');
+    expect(buildFilterBy<{ status: 'published' }>({ status: { $eq: 'published' } })).toBe('status:=`published`');
+    expect(buildFilterBy<{ price: number }>({ price: { $eq: 100 } })).toBe('price:=100');
+    expect(buildFilterBy<{ deleted: boolean }>({ deleted: { $eq: false } })).toBe('deleted:=false');
   });
 
   it('escapes backtick', () => {
-    expect(buildFilterBy<{ text: string }>({ text: { $eq: 'Sample `text`' } })).toBe('text:`Sample \\`text\\``');
+    expect(buildFilterBy<{ text: string }>({ text: { $eq: 'Sample `text`' } })).toBe('text:=`Sample \\`text\\``');
   });
 
   it('$ne', () => {
@@ -75,7 +75,7 @@ describe('buildFilterBy', () => {
           },
         ],
       })
-    ).toBe('((year:2020)||(year:2021))');
+    ).toBe('((year:=2020)||(year:=2021))');
   });
 
   it('uses $and by default', () => {
@@ -84,7 +84,7 @@ describe('buildFilterBy', () => {
         year: { $eq: 1995 },
         title: { $eq: 'Jumanji' },
       })
-    ).toBe('year:1995&&title:`Jumanji`');
+    ).toBe('year:=1995&&title:=`Jumanji`');
   });
 
   it('returns empty if no operator is used', () => {
@@ -172,6 +172,6 @@ describe('buildFilterBy', () => {
           },
         ],
       })
-    ).toBe('movies.available:true&&((movies.year:>=2020&&tags:[`horror`,`sci-fi`])||(movies.rating:>=4))');
+    ).toBe('movies.available:=true&&((movies.year:>=2020&&tags:[`horror`,`sci-fi`])||(movies.rating:>=4))');
   });
 });

--- a/src/buildFilterBy.ts
+++ b/src/buildFilterBy.ts
@@ -127,7 +127,7 @@ function next(node: unknown, path: string[]): string {
             break;
           }
           case '$eq': {
-            terms.push(`${path.join('.')}:${stringify(value)}`);
+            terms.push(`${path.join('.')}:=${stringify(value)}`);
             break;
           }
           case '$ne': {

--- a/src/buildSortBy.test.ts
+++ b/src/buildSortBy.test.ts
@@ -88,6 +88,6 @@ describe('buildSortBy', () => {
           },
         ],
       })
-    ).toBe('_eval(title:`The Witcher`):asc,_eval(available:true):desc');
+    ).toBe('_eval(title:=`The Witcher`):asc,_eval(available:=true):desc');
   });
 });


### PR DESCRIPTION
This fix makes the operator `$eq` to match by exact value and not by fuzzy.

## Use Case

Given a document:

```json
{
  "title": "Train (Express)"
}
```

and a query

```
{
  title: { 
    $eq: "Train"
  }
}
```

the resulting string query will be 

```
title:`Train`
```

As a result, TypeSense will match using a fuzzy match and not the expected match by exact. Instead, one expects that `$eq` will match by exact. The query above should have returned no matches.