### PR TITLE
fix: allow field type to reference other field types

### DIFF
--- a/src/Field.ts
+++ b/src/Field.ts
@@ -1,15 +1,13 @@
 import { Geopoint } from './Geopoint';
 
-export type Field<
-  Next,
-  Type = boolean | number | string | Geopoint,
-  Path extends string | undefined = undefined
-> = Next extends Type
+type _Field<Next, Path extends string | undefined = undefined> = Next extends boolean | number | string | Geopoint
   ? Path
   : Next extends (infer U)[]
-  ? Field<U, Type, Path>
+  ? _Field<U, Path>
   : Next extends object
   ? {
-      [K in keyof Next & string]: Field<Next[K], Type, Path extends string ? `${Path}.${K}` : K>;
+      [K in keyof Next & string]: _Field<Next[K], Path extends string ? `${Path}.${K}` : K>;
     }[keyof Next & string]
   : never;
+
+export type Field<Next> = _Field<Next>;

--- a/src/buildQueryBy.test.ts
+++ b/src/buildQueryBy.test.ts
@@ -12,6 +12,8 @@ interface Tour {
 
 describe('buildQueryBy', () => {
   it('composes an expression', () => {
-    expect(buildQueryBy<Museum>(['name', 'tours.language'])).toEqual('name,tours.language');
+    expect(buildQueryBy<Museum>(['name', 'tours.language', 'tours.starts_at'])).toEqual(
+      'name,tours.language,tours.starts_at'
+    );
   });
 });

--- a/src/buildQueryBy.ts
+++ b/src/buildQueryBy.ts
@@ -5,6 +5,6 @@ import type { Field } from './Field';
  *
  * https://typesense.org/docs/0.24.0/api/search.html#query-parameters
  */
-export function buildQueryBy<T>(fields: Field<T, string>[]) {
+export function buildQueryBy<T>(fields: Field<T>[]) {
   return fields.join(',');
 }


### PR DESCRIPTION
`Field` type does not allow to reference other field types. Thus, one can't reference a number field as an example. This PR fixes this problem.

<img width="800" alt="image" src="https://github.com/igrek8/typesense-utils/assets/7078731/3e2cc6a6-4992-497a-bb5c-7cd2ebfae4f9">
