### PR TITLE
fix: make `$in` operator match exact strings

### DIFF
--- a/src/buildFilterBy.test.ts
+++ b/src/buildFilterBy.test.ts
@@ -35,9 +35,9 @@ describe('buildFilterBy', () => {
 
   it('$in', () => {
     expect(buildFilterBy<{ years: number[] }>({ years: { $in: [2022, 2023] } })).toBe('years:[2022,2023]');
-    expect(buildFilterBy<{ colors: string[] }>({ colors: { $in: ['Blue', 'Red'] } })).toBe('colors:[`Blue`,`Red`]');
+    expect(buildFilterBy<{ colors: string[] }>({ colors: { $in: ['Blue', 'Red'] } })).toBe('colors:=[`Blue`,`Red`]');
     expect(buildFilterBy<{ checks: boolean[] }>({ checks: { $in: [false] } })).toBe('checks:[false]');
-    expect(buildFilterBy<{ state: 'on' | 'off' }>({ state: { $in: ['on', 'off'] } })).toBe('state:[`on`,`off`]');
+    expect(buildFilterBy<{ state: 'on' | 'off' }>({ state: { $in: ['on', 'off'] } })).toBe('state:=[`on`,`off`]');
   });
 
   it('$and', () => {
@@ -172,6 +172,6 @@ describe('buildFilterBy', () => {
           },
         ],
       })
-    ).toBe('movies.available:=true&&((movies.year:>=2020&&tags:[`horror`,`sci-fi`])||(movies.rating:>=4))');
+    ).toBe('movies.available:=true&&((movies.year:>=2020&&tags:=[`horror`,`sci-fi`])||(movies.rating:>=4))');
   });
 });

--- a/src/buildFilterBy.ts
+++ b/src/buildFilterBy.ts
@@ -144,8 +144,8 @@ function next(node: unknown, path: string[]): string {
           }
           case '$in': {
             assert(Array.isArray(value));
-            const sign = value.some((v) => typeof v === 'string') ? ':=' : ':';
-            terms.push(`${path.join('.')}${sign}[${value.map(stringify).join(',')}]`);
+            const operator = value.some((v) => typeof v === 'string') ? ':=' : ':';
+            terms.push(`${path.join('.')}${operator}[${value.map(stringify).join(',')}]`);
             break;
           }
           case '$polygon': {

--- a/src/buildFilterBy.ts
+++ b/src/buildFilterBy.ts
@@ -144,7 +144,8 @@ function next(node: unknown, path: string[]): string {
           }
           case '$in': {
             assert(Array.isArray(value));
-            terms.push(`${path.join('.')}:[${value.map(stringify).join(',')}]`);
+            const sign = value.some((v) => typeof v === 'string') ? ':=' : ':';
+            terms.push(`${path.join('.')}${sign}[${value.map(stringify).join(',')}]`);
             break;
           }
           case '$polygon': {


### PR DESCRIPTION
Fixes #66 

In the current implementation of `buildFilterBy`, using an `$in` filter with a string array does not do exact filtering of the values provided. The string filtering implementation is slightly different than the number filtering implementation due to the requirements of exact matching, [documented in Typesense's filter parameters](https://typesense.org/docs/0.25.2/api/search.html#filter-parameters):
> Exact Filtering:
> To match a string field exactly, you can use the := operator. For eg: category:= Shoe will match documents from the category shoes and not from a category like shoe rack.

This PR  updates the `$in` builder to use the `:=` operator for on `string[]` values while maintaining the current behavior for `number[]` values.